### PR TITLE
Use Click for command line arguments parsing

### DIFF
--- a/beangulp/__init__.py
+++ b/beangulp/__init__.py
@@ -8,7 +8,110 @@ hierarchy for preservation.
 __copyright__ = "Copyright (C) 2016,2018  Martin Blais"
 __license__ = "GNU GPLv2"
 
-# Register our test helper for rewriting. This has to be done in the parent
-# package because it has to run before the first time the module is imported.
-import pytest
-pytest.register_assert_rewrite('beangulp.regression_pytest')
+import os
+import sys
+import click
+
+from beancount import loader
+from beangulp import extract
+from beangulp import file
+from beangulp import identify
+from beangulp import importer
+
+
+@click.command('extract')
+@click.argument('src', nargs=-1, type=click.Path(exists=True, resolve_path=True))
+@click.option('--output', '-o', type=click.File('w'), default='-',
+              help='Output file.')
+@click.option('--existing', '-e', type=click.Path(exists=True),
+              help='Existing Beancount ledger for de-duplication.')
+@click.option('--reverse', '-r', is_flag=True,
+              help='Sort entries in reverse order.')
+@click.pass_obj
+def _extract(ctx, src, output, existing, reverse):
+    """Extract transactions from documents."""
+
+    # Load the ledger, if one is specified.
+    if existing:
+        entries, _, options_map = loader.load_file(existing)
+    else:
+        entries, options_map = None, None
+
+    ctx.extract(src, output,
+                entries=entries,
+                options_map=options_map,
+                mindate=None,
+                ascending=not reverse)
+
+
+@click.command('file')
+@click.argument('src', nargs=-1, type=click.Path(exists=True, resolve_path=True))
+@click.option('--destination', '-o',
+              type=click.Path(exists=True, file_okay=False), metavar='DIR',
+              help='The destination documents tree root directory.')
+@click.option('--dry-run', '-n', is_flag=True,
+              help='Just print where the files would be moved.')
+@click.option('--overwrite', '-f', is_flag=True,
+              help='Overwrite destination files with the same name.')
+@click.pass_obj
+def _file(ctx, src, destination, dry_run, overwrite):
+    """File away documents.
+
+    Walk the list of SRC filenames or directories of downloaded files,
+    and for each of those files, move the file under a filing
+    directory corresponding to the assocaited account.
+
+    """
+    # If the output directory is not specified, move the files at the
+    # root where the import script is located. Providing this default
+    # seems better than using a required option.
+    if destination is None:
+        # pylint: disable=import-outside-toplevel
+        import __main__
+        destination = os.path.dirname(os.path.abspath(__main__.__file__))
+
+    ctx.file(src, destination,
+             dry_run=dry_run,
+             mkdirs=True,
+             overwrite=overwrite,
+             idify=True,
+             logfile=sys.stdout)
+
+
+@click.command('identify')
+@click.argument('src', nargs=-1, type=click.Path(exists=True, resolve_path=True))
+@click.pass_obj
+def _identify(ctx, src):
+    """Identify files for import."""
+    return ctx.identify(src)
+
+
+class Ingest:
+    def __init__(self, importers, hooks=None):
+        self.importers = importers
+        self.hooks = hooks
+
+        @click.group()
+        @click.version_option()
+        @click.pass_context
+        def main(ctx):
+            """Import data from and file away documents from financial institutions."""
+            ctx.obj = self
+
+        main.add_command(_extract)
+        main.add_command(_file)
+        main.add_command(_identify)
+
+        self.main = main
+
+    def extract(self, what, *args, **kwargs):
+        extract.extract(self.importers, what, *args, hooks=self.hooks, **kwargs)
+
+    def file(self, what, *args, **kwargs):
+        file.file(self.importers, what, *args, **kwargs)
+
+    def identify(self, what, *args, **kwargs):
+        identify.identify(self.importers, what, *args, **kwargs)
+
+    def __call__(self):
+        return self.main()

--- a/beangulp/extract.py
+++ b/beangulp/extract.py
@@ -9,7 +9,6 @@ __license__ = "GNU GPLv2"
 import itertools
 import inspect
 import logging
-import sys
 import textwrap
 
 from beancount.core import data
@@ -17,7 +16,6 @@ from beancount.parser import printer
 from beangulp import similar
 from beangulp import identify
 from beangulp import cache
-from beancount import loader
 
 
 # The format for the header in the extracted output.
@@ -212,38 +210,3 @@ def extract(importer_config,
         if not ascending:
             new_entries.reverse()
         print_extracted_entries(new_entries, output)
-
-
-DESCRIPTION = "Extract transactions from downloads"
-
-
-def add_arguments(parser):
-    """Add arguments for the extract command."""
-
-    parser.add_argument('-e', '-f', '--existing', '--previous', metavar='BEANCOUNT_FILE',
-                        default=None,
-                        help=('Beancount file or existing entries for de-duplication '
-                              '(optional)'))
-
-    parser.add_argument('-r', '--reverse', '--descending',
-                        action='store_const', dest='ascending',
-                        default=True, const=False,
-                        help='Write out the entries in descending order')
-
-
-def run(args, _, importers_list, files_or_directories, hooks=None):
-    """Run the subcommand."""
-
-    # Load the ledger, if one is specified.
-    if args.existing:
-        entries, _, options_map = loader.load_file(args.existing)
-    else:
-        entries, options_map = None, None
-
-    extract(importers_list, files_or_directories, sys.stdout,
-            entries=entries,
-            options_map=options_map,
-            mindate=None,
-            ascending=args.ascending,
-            hooks=hooks)
-    return 0

--- a/beangulp/file.py
+++ b/beangulp/file.py
@@ -1,9 +1,3 @@
-"""Filing script.
-
-Read an import script and a list of downloaded filenames or directories of
-downloaded files, and for each of those files, move the file under an account
-corresponding to the filing directory.
-"""
 __copyright__ = "Copyright (C) 2016  Martin Blais"
 __license__ = "GNU GPLv2"
 
@@ -13,7 +7,6 @@ import datetime
 import logging
 import os
 import shutil
-import sys
 import re
 
 from beancount.core import account
@@ -222,7 +215,7 @@ def file(importer_config,
     # If there are any errors, just don't do anything at all. This is a nicer
     # behaviour than moving just *some* files.
     if dry_run or has_errors:
-        return
+        return None
 
     # Actually carry out the moving job.
     for old_filename, new_filename in jobs:
@@ -255,49 +248,3 @@ def move_xdev_file(src_filename, dst_filename, mkdirs=False):
     # cross-device moves, because it's sensible that the destination might
     # be on an encrypted device.
     os.remove(src_filename)
-
-
-DESCRIPTION = ("Move and rename downloaded files to a documents tree "
-               "mirroring the chart of accounts")
-
-
-def add_arguments(parser):
-    """Add arguments for the extract command."""
-
-    parser.add_argument('-o', '--output', '--output-dir', '--destination',
-                        dest='output_dir', action='store',
-                        help="The root of the documents tree to move the files to.")
-
-    parser.add_argument('-n', '--dry-run', action='store_true',
-                        help=("Just print where the files would be moved; "
-                              "don't actually move them."))
-
-    parser.add_argument('--no-overwrite', dest='overwrite',
-                        action='store_false', default=True,
-                        help="Don't overwrite destination files with the same name.")
-
-
-def run(args, parser, importers_list, files_or_directories, hooks=None):
-    """Run the subcommand."""
-
-    # If the output directory is not specified, move the files at the root where
-    # the import configuration file is located. (Providing this default seems
-    # better than using a required option.)
-    if args.output_dir is None:
-        if hasattr(args, 'config'):
-            args.output_dir = path.dirname(path.abspath(args.config))
-        else:
-            import __main__ # pylint: disable=import-outside-toplevel
-            args.output_dir = path.dirname(path.abspath(__main__.__file__))
-
-    # Make sure the output directory exists.
-    if not path.exists(args.output_dir):
-        parser.error('Output directory "{}" does not exist.'.format(args.output_dir))
-
-    file(importers_list, files_or_directories, args.output_dir,
-         dry_run=args.dry_run,
-         mkdirs=True,
-         overwrite=args.overwrite,
-         idify=True,
-         logfile=sys.stdout)
-    return 0

--- a/beangulp/file_test.py
+++ b/beangulp/file_test.py
@@ -13,6 +13,7 @@ import warnings
 
 from beancount.utils import test_utils
 from beancount.utils import file_utils
+
 from beangulp import file
 from beangulp.test_utils import TestScriptsBase, TestExamplesBase
 
@@ -24,15 +25,6 @@ class TestScriptFile(TestScriptsBase, test_utils.TestCase):
         self.downloads = path.join(self.tempdir, 'Downloads')
         self.documents = path.join(self.tempdir, 'Documents')
         os.mkdir(self.documents)
-
-    def test_file_main__output_dir_does_not_exist(self):
-        with test_utils.capture('stdout', 'stderr') as (stdout, stderr):
-            with self.assertRaises(SystemExit):
-                test_utils.run_with_args(
-                    self.ingest,
-                    ['-d', self.tempdir, 'file',
-                     '--output', path.join(self.documents, "Bogus")],
-                    file.__file__)
 
     def test_move_xdev_file(self):
         file.move_xdev_file(
@@ -316,12 +308,8 @@ class TestScriptFile(TestScriptsBase, test_utils.TestCase):
         self.assertEqual(args[2], exc)
 
     def test_file(self):
-        with test_utils.capture('stdout', 'stderr') as (stdout, stderr):
-            test_utils.run_with_args(
-                self.ingest,
-                ['-d', path.join(self.tempdir, 'Downloads'),
-                 'file', '--output', self.documents],
-                file.__file__)
+        downloads = path.join(self.tempdir, 'Downloads')
+        result= self.ingest('file', downloads, '-o', self.documents)
         expected_res = [
             path.join(self.documents, x)
             for x in [r'Liabilities/CreditCard/\d\d\d\d-\d\d-\d\d\.bank\.csv',
@@ -339,14 +327,9 @@ class TestFileExamples(TestExamplesBase, TestScriptsBase):
             'ignore', module='html5lib', category=DeprecationWarning,
             message='Using or importing the ABCs from')
 
-        with test_utils.capture('stdout', 'stderr') as (_, stderr):
-            result = test_utils.run_with_args(
-                self.ingest,
-                ['-d', path.join(self.tempdir, 'Downloads'),
-                 'file', '--output={}'.format(self.tempdir)],
-                file.__file__)
-        self.assertEqual(0, result)
-        self.assertEqual("", stderr.getvalue())
+        downloads = path.join(self.tempdir, 'Downloads')
+        result = self.ingest('file', downloads, '-o', self.tempdir)
+        self.assertEqual(result.exit_code, 0)
 
         filed_files = []
         for root, dirs, files in os.walk(self.tempdir):

--- a/beangulp/identify.py
+++ b/beangulp/identify.py
@@ -85,15 +85,3 @@ def identify(importers_list, files_or_directories):
             logfile.write('Importer:    {}\n'.format(importer.name() if importer else '-'))
             logfile.write('Account:     {}\n'.format(importer.file_account(file)))
             logfile.write('\n')
-
-
-DESCRIPTION = "Identify files for import"
-
-
-def add_arguments(parser):
-    """Add arguments for the identify command."""
-
-
-def run(_, __, importers_list, files_or_directories, hooks=None):
-    """Run the subcommand."""
-    return identify(importers_list, files_or_directories)

--- a/beangulp/identify_test.py
+++ b/beangulp/identify_test.py
@@ -83,26 +83,20 @@ class TestScriptIdentify(TestScriptsBase):
 
             """).strip()
 
-        with test_utils.capture('stdout', 'stderr') as (stdout, stderr):
-            test_utils.run_with_args(
-                self.ingest, ['-d', path.join(self.tempdir, 'Downloads'), 'identify'],
-                identify.__file__)
-        output = stdout.getvalue().strip()
+        downloads = path.join(self.tempdir, 'Downloads')
+        result = self.ingest('identify', downloads)
+        output = result.stdout
         self.assertTrue(re.match(regexp, output))
 
 
 class TestIdentifyExamples(TestExamplesBase, TestScriptsBase):
 
     def test_identify_examples(self):
-        with test_utils.capture('stdout', 'stderr') as (stdout, stderr):
-            result = test_utils.run_with_args(
-                self.ingest, ['-d', path.join(self.example_dir, 'Downloads'), 'identify'],
-                identify.__file__)
+        downloads = path.join(self.example_dir, 'Downloads')
+        result = self.ingest('identify', downloads)
 
-        self.assertEqual(0, result)
-        output = stdout.getvalue()
-        errors = stderr.getvalue()
-        self.assertTrue(not errors or re.search('ERROR.*pdf2txt', errors))
+        self.assertEqual(result.exit_code, 0)
+        output = result.stdout
 
         self.assertRegex(output, 'Downloads/UTrade20160215.csv')
         self.assertRegex(output, 'Importer:.*importers.utrade.utrade_csv.Importer')

--- a/beangulp/scripts_utils.py
+++ b/beangulp/scripts_utils.py
@@ -1,89 +1,10 @@
-"""Common front-end to all ingestion tools.
-"""
 __copyright__ = "Copyright (C) 2016,2018  Martin Blais"
 __license__ = "GNU GPLv2"
 
-import os
-import sys
+from beangulp import Ingest
 
-from beancount.parser import version
-from beangulp import identify
-from beangulp import extract
-from beangulp import file
-
-
-DESCRIPTION = ("Identify, extract or file away data downloaded from "
-               "financial institutions.")
-
-
-def ingest(importers_list, hooks=None):
-    """Driver function that calls all the ingestion tools.
-
-    Put a call to this function at the end of your importer configuration to
-    make your import script; this should be its main function, like this:
-
-      from beangulp.scripts_utils import ingest
-      my_importers = [ ... ]
-      ingest(my_importers)
-
-    This more explicit way of invoking the ingestion is now the preferred way to
-    invoke the various tools, and replaces calling the bean-identify,
-    bean-extract, bean-file tools with a --config argument. When you call the
-    import script itself (as as program) it will parse the arguments, expecting
-    a subcommand ('identify', 'extract' or 'file') and corresponding
-    subcommand-specific arguments.
-
-    Here you can override some importer values, such as installing a custom
-    duplicate finding hook, and eventually more. Note that this newer invocation
-    method is optional and if it is not present, a call to ingest() is generated
-    implicitly, and it functions as it used to. Future configurable
-    customization of the ingestion process will be implemented by inserting new
-    arguments to this function, this is the motivation behind doing this.
-
-    Note that invocation by the three bean-* ingestion tools is still supported,
-    and calling ingest() explicitly from your import configuration file will not
-    break these tools either, if you invoke them on it; the values you provide
-    to this function will be used by those tools.
-
-    Args:
-      importers_list: A list of importer instances. This is used as a
-        chain-of-responsibility, called on each file.
-      hooks: An optional list of hook functions to apply to the list of extract
-        (filename, entries) pairs, in order. This replaces
-        'detect_duplicates_func'.
-    """
-
-    parser = version.ArgumentParser(description=DESCRIPTION)
-
-    # Use required on subparsers.
-    # FIXME: Remove this when we require version 3.7 or above.
-    kwargs = {}
-    if sys.version_info >= (3, 7):
-        kwargs['required'] = True
-    subparsers = parser.add_subparsers(dest='command', **kwargs)
-
-    parser.add_argument('--downloads', '-d', metavar='DIR-OR-FILE',
-                        action='append', default=[],
-                        help='Filenames or directories to search for files to import')
-
-    for cmdname, module in [('identify', identify),
-                            ('extract', extract),
-                            ('file', file)]:
-        parser_cmd = subparsers.add_parser(cmdname, help=module.DESCRIPTION)
-        parser_cmd.set_defaults(command=module.run)
-        module.add_arguments(parser_cmd)
-
-    args = parser.parse_args()
-
-    if not args.downloads:
-        args.downloads.append(os.getcwd())
-
-    # Implement required ourselves.
-    # FIXME: Remove this when we require version 3.7 or above.
-    if not (sys.version_info >= (3, 7)):
-        if not hasattr(args, 'command'):
-            parser.error("Subcommand is required.")
-
-    abs_downloads = list(map(os.path.abspath, args.downloads))
-    args.command(args, parser, importers_list, abs_downloads, hooks=hooks)
-    return 0
+def ingest(importers, hooks=None):
+    # This function is provided for backward compatibility with the
+    # ``beancount.ingest`` framework. It will be removed eventually.
+    main = Ingest(importers, hooks)
+    main()


### PR DESCRIPTION
This it the first step toward the goal of providing an easily
customizable and extensible framework with integrate testing
facilities for importers.  The old ``beancount.ingest`` API is
preserved under the ``beangulp`` namespace, however the CLI is
modernize and improved.  Further changes are expected.  The
autogenerated command line help text (see ``--help`` command line
option to the main scritp and to the sub-commands) should be enough to
understand how to use it.  Extended documentation will follow.