### PR TITLE
cache: Add disk cache decorator

### DIFF
--- a/examples/office/importers/acme/acme_pdf.py
+++ b/examples/office/importers/acme/acme_pdf.py
@@ -18,17 +18,13 @@ import subprocess
 from dateutil.parser import parse as parse_datetime
 
 from beangulp import importer
+from beangulp.cache import cache
 from beangulp.testing import main
 
 
+@cache
 def pdf_to_text(filename):
-    """Convert a PDF file to a text equivalent.
-
-    Args:
-      filename: A string path, the filename to convert.
-    Returns:
-      A string, the text contents of the filename.
-    """
+    """Convert a PDF document to a text equivalent."""
     r = subprocess.run(['pdftotext', filename, '-'],
                        stdout=subprocess.PIPE, check=True)
     return r.stdout.decode()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,171 @@
+import os
+import shutil
+import tempfile
+import time
+import unittest
+
+import beangulp.cache
+import beangulp.testing
+
+
+class CacheTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        beangulp.cache.CACHEDIR = os.path.join(self.tempdir, 'cache')
+        os.mkdir(beangulp.cache.CACHEDIR)
+        self.filename = os.path.join(self.tempdir, 'test.txt')
+        with open(self.filename, 'w') as f:
+            pass
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_no_cache(self):
+        counter = 0
+
+        def func(filename):
+            nonlocal counter
+            counter +=1
+            return counter
+
+        r = func(self.filename)
+        self.assertEqual(r, 1)
+
+        r = func(self.filename)
+        self.assertEqual(r, 2)
+
+    def test_cache(self):
+        counter = 0
+
+        @beangulp.cache.cache
+        def func(filename):
+            nonlocal counter
+            counter +=1
+            return counter
+
+        r = func(self.filename)
+        self.assertEqual(r, 1)
+
+        r = func(self.filename)
+        self.assertEqual(r, 1)
+
+    def test_cache_expire_mtime(self):
+        counter = 0
+
+        @beangulp.cache.cache
+        def func(filename):
+            nonlocal counter
+            counter +=1
+            return counter
+
+        r = func(self.filename)
+        self.assertEqual(r, 1)
+
+        r = func(self.filename)
+        self.assertEqual(r, 1)
+
+        t = time.time() + 2.0
+        os.utime(self.filename, (t, t))
+
+        r = func(self.filename)
+        self.assertEqual(r, 2)
+
+        r = func(self.filename)
+        self.assertEqual(r, 2)
+
+    def test_cache_expire_args(self):
+        counter = 0
+
+        @beangulp.cache.cache
+        def func(filename, arg):
+            nonlocal counter
+            counter +=1
+            return counter
+
+        r = func(self.filename, 1)
+        self.assertEqual(r, 1)
+
+        r = func(self.filename, 1)
+        self.assertEqual(r, 1)
+
+        r = func(self.filename, 2)
+        self.assertEqual(r, 2)
+
+    def test_cache_expire_override(self):
+        counter = 0
+
+        @beangulp.cache.cache
+        def func(filename):
+            nonlocal counter
+            counter +=1
+            return counter
+
+        r = func(self.filename)
+        self.assertEqual(r, 1)
+
+        r = func(self.filename)
+        self.assertEqual(r, 1)
+
+        r = func(self.filename, cache=False)
+        self.assertEqual(r, 2)
+
+        r = func(self.filename, cache=True)
+        self.assertEqual(r, 2)
+
+        t = time.time() + 2.0
+        os.utime(self.filename, (t, t))
+
+        r = func(self.filename, cache=True)
+        self.assertEqual(r, 2)
+
+    def test_cache_reset_mtime(self):
+        counter = 0
+
+        @beangulp.cache.cache
+        def func(filename):
+            nonlocal counter
+            counter +=1
+            return counter
+
+        r = func(self.filename)
+        self.assertEqual(r, 1)
+
+        t = os.stat(self.filename).st_mtime_ns
+        with open(self.filename, 'w') as f:
+            f.write('baz')
+        os.utime(self.filename, ns=(t, t))
+
+        r = func(self.filename)
+        self.assertEqual(r, 1)
+
+    def test_cache_key_sha1(self):
+        counter = 0
+
+        @beangulp.cache.cache(key=beangulp.testing.sha1sum)
+        def func(filename):
+            nonlocal counter
+            counter +=1
+            return counter
+
+        with open(self.filename, 'w') as f:
+            f.write('test')
+
+        r = func(self.filename)
+        self.assertEqual(r, 1)
+
+        r = func(self.filename)
+        self.assertEqual(r, 1)
+
+        t = time.time() + 2.0
+        os.utime(self.filename, (t, t))
+
+        r = func(self.filename)
+        self.assertEqual(r, 1)
+
+        t = os.stat(self.filename).st_mtime_ns
+        with open(self.filename, 'w') as f:
+            f.write('baz')
+        os.utime(self.filename, ns=(t, t))
+
+        r = func(self.filename)
+        self.assertEqual(r, 2)


### PR DESCRIPTION
This is still missing documentation, but I know that @blais is eagerly waiting for something like this, thus this early PR to review. There are example of usage in the added tests. By default the cache is keyed on the filename and expired on the file modification time. However, this can be overwritten with the `key` argument to the cache decorator. In the tests there is an example for using the input file SHA1 digest. All arguments to the decorated function are always part of the cache key.

Which directory to use for the cache on WIndows? On Unix-like systems `~/.cache/beangulp/` is a good choice, but I don't have idea what would be the equivalent on Windows. Also, what should be the behavior when the cache directory does not exist? The implementation proposed simply raises  `FileNotFoundError` exception. Another possibility, would to silently disable the cache.