### PR TITLE
testing: Disable colors on dumb terminals

### DIFF
--- a/beangulp/testing.py
+++ b/beangulp/testing.py
@@ -114,9 +114,10 @@ def run_importer(importer: ImporterProtocol,
 
 def logger(verbosity: int):
     """Convenient logging method factory."""
+    color = False if os.getenv('TERM', '') in ('', 'dumb') else None
     def log(msg, level=0, **kwargs):
         if level <= verbosity:
-            click.secho(msg, **kwargs)
+            click.secho(msg, color=color, **kwargs)
     return log
 
 


### PR DESCRIPTION
Click does not checke the $TERM environment variable to decide whether
to emit color escape sequences as it is customarily done. This results
in the escape sequences emitted for example when the testing framework
is invoked within Emacs compilation mode. Do the check in our logging
wrapper.

Fixes #36.