### PR TITLE
New Importer interface

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -32,3 +32,9 @@ jobs:
           python importers/acme.py test importers_tests/acme --verbose
           python importers/csvbank.py test importers_tests/csvbank --verbose
           python importers/utrade.py test importers_tests/utrade --verbose
+      - name: Run example ledger.import
+        run: |
+          cd examples
+          python ledger/ledger.import identify Downloads -v
+          python ledger/ledger.import extract Downloads
+          python ledger/ledger.import archive Downloads -n -o documents

--- a/.pylintrc
+++ b/.pylintrc
@@ -24,6 +24,7 @@ disable=
   too-many-arguments,
   too-many-branches,
   too-many-locals,
+  too-many-return-statements,
   too-many-statements,
   undefined-loop-variable,
   unsubscriptable-object,

--- a/beangulp/archive.py
+++ b/beangulp/archive.py
@@ -6,7 +6,6 @@ import re
 import shutil
 
 from beancount.utils import misc_utils
-from beangulp import cache
 from beangulp import utils
 from beangulp.exceptions import Error
 
@@ -31,12 +30,10 @@ def filepath(importer, filepath: str) -> str:
       contain a date.
 
     """
-    file = cache.get_file(filepath)
-
     # Get the account corresponding to the file.
-    account = importer.file_account(file)
-    filename = importer.file_name(file) or os.path.basename(file.name)
-    date = importer.file_date(file) or utils.getmdate(file.name)
+    account = importer.account(filepath)
+    filename = importer.filename(filepath) or os.path.basename(filepath)
+    date = importer.date(filepath) or utils.getmdate(filepath)
 
     # The returned filename cannot contain the file path separator character.
     if os.sep in filename:

--- a/beangulp/archive.py
+++ b/beangulp/archive.py
@@ -5,7 +5,6 @@ import os
 import re
 import shutil
 
-from beancount.utils import misc_utils
 from beangulp import utils
 from beangulp.exceptions import Error
 
@@ -41,10 +40,6 @@ def filepath(importer, filepath: str) -> str:
 
     if re.match(r'\d\d\d\d-\d\d-\d\d', filename):
         raise Error("The filename contains what looks like a date.")
-
-    # Remove whitespace and other funny characters from the filename.
-    # TODO(dnicolodi): This should probably be importer responsibility.
-    filename = misc_utils.idify(filename)
 
     # Prepend account directory and date prefix.
     filename = os.path.join(account.replace(':', os.sep), f'{date:%Y-%m-%d}.{filename:}')

--- a/beangulp/archive_test.py
+++ b/beangulp/archive_test.py
@@ -16,7 +16,7 @@ class TestFilepath(unittest.TestCase):
 
     def test_filepath(self):
         importer = mock.MagicMock(wraps=self.importer)
-        importer.file_name.return_value = 'foo.csv'
+        importer.filename.return_value = 'foo.csv'
         filepath = archive.filepath(importer, path.abspath('test.pdf'))
         self.assertEqual(filepath, 'Assets/Tests/1970-01-01.foo.csv')
 
@@ -26,21 +26,21 @@ class TestFilepath(unittest.TestCase):
 
     def test_filepath_no_date(self):
         importer = mock.MagicMock(wraps=self.importer)
-        importer.file_date.return_value = None
+        importer.date.return_value = None
         with mock.patch('os.path.getmtime', return_value=86401):
             filepath = archive.filepath(importer, path.abspath('test.pdf'))
         self.assertEqual(filepath, 'Assets/Tests/1970-01-02.test.pdf')
 
     def test_filepath_sep_in_name(self):
         importer = mock.MagicMock(wraps=self.importer)
-        importer.file_name.return_value = f'dir{os.sep:}name.pdf'
+        importer.filename.return_value = f'dir{os.sep:}name.pdf'
         with self.assertRaises(exceptions.Error) as ex:
             filepath = archive.filepath(importer, path.abspath('test.pdf'))
         self.assertRegex(ex.exception.message, r'contains path separator')
 
     def test_filepath_date_in_name(self):
         importer = mock.MagicMock(wraps=self.importer)
-        importer.file_name.return_value = '1970-01-03.name.pdf'
+        importer.filename.return_value = '1970-01-03.name.pdf'
         with self.assertRaises(exceptions.Error) as ex:
             filepath = archive.filepath(importer, path.abspath('test.pdf'))
         self.assertRegex(ex.exception.message, r'contains [\w\s]+ date')

--- a/beangulp/extract.py
+++ b/beangulp/extract.py
@@ -35,8 +35,8 @@ def extract_from_file(importer, filename, existing_entries):
     if not entries:
         return []
 
-    # Make sure the newly imported entries are sorted; don't trust the importer.
-    entries.sort(key=data.entry_sortkey)
+    # Sort the newly imported entries.
+    importer.sort(entries)
 
     # Ensure that the entries are typed correctly.
     for entry in entries:

--- a/beangulp/extract.py
+++ b/beangulp/extract.py
@@ -1,13 +1,10 @@
 __copyright__ = "Copyright (C) 2016-2017  Martin Blais"
 __license__ = "GNU GPLv2"
 
-import inspect
 import textwrap
 
 from beancount.core import data
 from beancount.parser import printer
-
-from beangulp import cache
 from beangulp import similar
 
 
@@ -34,15 +31,9 @@ def extract_from_file(importer, filename, existing_entries):
     Returns:
       The list of imported entries.
     """
-    file = cache.get_file(filename)
-
-    # Support calling without the existing entries.
-    kwargs = {}
-    if 'existing_entries' in inspect.signature(importer.extract).parameters:
-        kwargs['existing_entries'] = existing_entries
-    entries = importer.extract(file, **kwargs)
-    if entries is None:
-        entries = []
+    entries = importer.extract(filename, existing_entries)
+    if not entries:
+        return []
 
     # Make sure the newly imported entries are sorted; don't trust the importer.
     entries.sort(key=data.entry_sortkey)

--- a/beangulp/extract_test.py
+++ b/beangulp/extract_test.py
@@ -31,7 +31,7 @@ class TestExtract(unittest.TestCase):
               Assets:Tests  1.00 USD
             '''))
 
-        importer = mock.MagicMock(spec=self.importer)
+        importer = mock.MagicMock(wraps=self.importer)
         importer.extract.return_value = entries
         entries = extract.extract_from_file(importer, path.abspath('test.csv'), [])
         dates = [entry.date for entry in entries]
@@ -45,7 +45,7 @@ class TestExtract(unittest.TestCase):
 
         # Break something.
         entries[-1] = entries[-1]._replace(narration=42)
-        importer = mock.MagicMock(spec=self.importer)
+        importer = mock.MagicMock(wraps=self.importer)
         importer.extract.return_value = entries
         with self.assertRaises(AssertionError):
             extract.extract_from_file(importer, path.abspath('test.csv'), [])

--- a/beangulp/identify.py
+++ b/beangulp/identify.py
@@ -1,7 +1,6 @@
 __copyright__ = "Copyright (C) 2016  Martin Blais"
 __license__ = "GNU GPLv2"
 
-from beangulp import cache
 from beangulp.exceptions import Error
 
 
@@ -26,11 +25,9 @@ def identify(importers, filepath: str):
       beangulp.exceptions.Error: More than one importer matched the file.
 
     """
-    file = cache.get_file(filepath)
-
-    match = [ importer for importer in importers if importer.identify(file) ]
+    match = [ importer for importer in importers if importer.identify(filepath) ]
     if len(match) > 1:
-        match = [ importer.name() for importer in match ]
+        match = [ importer.name for importer in match ]
         raise Error('Document identified by more than one importer.', *match)
 
     return match[0] if match else None

--- a/beangulp/identify_test.py
+++ b/beangulp/identify_test.py
@@ -22,10 +22,10 @@ class TestIdentify(unittest.TestCase):
         self.assertIsNone(importer)
 
         importer = identify.identify(importers, path.abspath('test.pdf'))
-        self.assertEqual(importer.name(), 'A')
+        self.assertEqual(importer.name, 'A')
 
         importer = identify.identify(importers, path.abspath('test.csv'))
-        self.assertEqual(importer.name(), 'B')
+        self.assertEqual(importer.name, 'B')
 
     def test_identify_collision(self):
         importers = [

--- a/beangulp/importer.py
+++ b/beangulp/importer.py
@@ -118,6 +118,25 @@ class Importer(abc.ABC):
         """
         return []
 
+    def sort(self, entries: data.Entries, reverse=False) -> None:
+        """Sort the extracted directives.
+
+        The sort is in-place and stable. The reverse flag can be set
+        to sort in descending order. Importers can implement this
+        method to have entries serialized to file in a specific
+        order. The default implementation sorts the entries according
+        to beancount.core.data.entry_sortkey().
+
+        Args:
+          entries: Entries list to sort.
+          reverse: When True sort in descending order.
+
+        Returns:
+          None.
+
+        """
+        return entries.sort(key=data.entry_sortkey, reverse=reverse)
+
 
 class ImporterProtocol:
     """Old importers interface, superseded by the Importer ABC.

--- a/beangulp/importer.py
+++ b/beangulp/importer.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from beancount.core import flags
 from beancount.core import data
+from beancount.utils import misc_utils
 from beangulp import cache
 
 
@@ -175,7 +176,12 @@ class Adapter(Importer):
         return self.importer.file_date(cache.get_file(filepath))
 
     def filename(self, filepath):
-        return self.importer.file_name(cache.get_file(filepath))
+        filename = self.importer.file_name(cache.get_file(filepath))
+        # The current implementation of the archive command does not
+        # modify the filename returned by the importer. This preserves
+        # backward compatibility with the old implementation of the
+        # command.
+        return misc_utils.idify(filename)
 
     def extract(self, filepath, existing):
         p = inspect.signature(self.importer.extract).parameters

--- a/beangulp/similar.py
+++ b/beangulp/similar.py
@@ -5,8 +5,8 @@ This can be used during import in order to identify and flag duplicate entries.
 __copyright__ = "Copyright (C) 2016  Martin Blais"
 __license__ = "GNU GPLv2"
 
-import datetime
 import collections
+import datetime
 
 from beancount.core.number import D
 from beancount.core.number import ZERO

--- a/beangulp/tests/archive.rst
+++ b/beangulp/tests/archive.rst
@@ -12,13 +12,13 @@ An importer to create error conditions:
 
   >>> class ErrorImporter(Importer):
   ...
-  ...     def identify(self, f):
-  ...         name = path.basename(f.name)
+  ...     def identify(self, filepath):
+  ...         name = path.basename(filepath)
   ...         if name == 'error.foo':
   ...             return True
   ...         return False
   ...
-  ...     def file_name(self, f):
+  ...     def filename(self, filepath):
   ...         return 'bbb.csv'
 
 Test harness:

--- a/beangulp/tests/extract.rst
+++ b/beangulp/tests/extract.rst
@@ -12,14 +12,8 @@ An importer to create error conditions:
 
   >>> class ErrorImporter(Importer):
   ...
-  ...     def extract(self, f):
-  ...         name = path.basename(f.name)
-  ...         if name == 'error.foo':
-  ...             return True
-  ...         return False
-  ...
-  ...     def extract(self, f):
-  ...         name = path.basename(f.name)
+  ...     def extract(self, filepath, existing):
+  ...         name = path.basename(filepath)
   ...         raise ValueError(name)
 
 Test harness:

--- a/beangulp/tests/identify.rst
+++ b/beangulp/tests/identify.rst
@@ -12,8 +12,8 @@ An importer to create error conditions:
 
   >>> class ErrorImporter(Importer):
   ...
-  ...     def identify(self, f):
-  ...         name = path.basename(f.name)
+  ...     def identify(self, filepath):
+  ...         name = path.basename(filepath)
   ...         # An exception raised from importer code.
   ...         if name == 'error.txt':
   ...             raise ValueError(name)

--- a/beangulp/tests/utils.py
+++ b/beangulp/tests/utils.py
@@ -3,27 +3,28 @@ from beangulp import importer
 from beangulp import mimetypes
 
 
-class Importer(importer.ImporterProtocol):
+class Importer(importer.Importer):
     def __init__(self, name, account, mimetype):
         self._name = name
         self._account = account
         self._mimetype = mimetype
 
+    @property
     def name(self):
         return self._name
 
-    def identify(self, file):
-        mimetype, encoding = mimetypes.guess_type(file.name, False)
+    def identify(self, filepath):
+        mimetype, encoding = mimetypes.guess_type(filepath, False)
         return mimetype == self._mimetype
 
-    def file_date(self, file):
+    def date(self, filepath):
         return date(1970, 1, 1)
 
-    def file_account(self, file):
+    def account(self, filepath):
         return self._account
 
-    def file_name(self, file):
+    def filename(self, filepath):
         return None
 
-    def extract(self, file, existing_entries=None):
+    def extract(self, filepath, existing):
         return []

--- a/beangulp/tests/utils.py
+++ b/beangulp/tests/utils.py
@@ -28,3 +28,7 @@ class Importer(importer.Importer):
 
     def extract(self, filepath, existing):
         return []
+
+    def deduplicate(self, entries, existing):
+        # Opt-out from the default deduplication mechanism.
+        return entries

--- a/examples/importers/utrade.py
+++ b/examples/importers/utrade.py
@@ -174,6 +174,38 @@ class Importer(beangulp.Importer):
 
         return entries
 
+    @staticmethod
+    def cmp(a, b):
+        # This importer attaches an unique ID to all transactions in
+        # the form of a link. The link can be used to implement
+        # transaction duplicates detection based on transactions IDs.
+
+        if not isinstance(a, data.Transaction):
+            return False
+        if not isinstance(b, data.Transaction):
+            return False
+
+        # Get all the links with the expected ut$ID format.
+        aids = [link for link in a.links if re.match(r'ut\d{8}', link)]
+        if not aids:
+            # If there are no matching links, stop here.
+            return False
+
+        # Get all the links with the expected ut$ID format.
+        bids = [link for link in b.links if re.match(r'ut\d{8}', link)]
+        if not bids:
+            # If there are no matching links, stop here.
+            return False
+
+        if len(aids) != len(bids):
+            return False
+
+        # Compare all collected IDs.
+        if all(aid == bid for aid, bid in zip(sorted(aids), sorted(bids))):
+            return True
+
+        return False
+
 
 if __name__ == '__main__':
     importer = Importer(

--- a/examples/ledger/ledger.import
+++ b/examples/ledger/ledger.import
@@ -6,7 +6,6 @@ importers_path = path.dirname(path.dirname(path.abspath(__file__)))
 sys.path.insert(0, importers_path)
 
 from beancount.core import data
-from beangulp.extract import find_duplicate_entries
 import beangulp
 
 # Import custom importers.
@@ -74,7 +73,7 @@ def process_extracted_entries(extracted_entries_list, ledger_entries):
             for filename, entries in extracted_entries_list]
 
 
-hooks = [process_extracted_entries, find_duplicate_entries]
+hooks = [process_extracted_entries]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a proposal for a new Import interface.

Compared to the existing interface it
- drops the use of the memory cache,
- changes `name` from a function to an attribute (implemented as a property, in the base class),
- renames some of the methods,
- adds the `sortkey` static method and the `sort()` and `filter()` methods.

The `sortkey()` static method is used by the base class implementation of the `sort()` method in the obvious way. The `sort()` method allows to customize sorting of the entries extracted by the importer, defaulting to the current sorting. The `filter()` method allows to post-process the extracted entries, for example to plug in auto categorization of transactions.

I am debated whether an explicit `deduplicate()` method, maybe using  `cmp()` method under the hood, should be added.

An alternative approach could be to remove deduplication and filrering from the ingest tool and move them to a separate tool.

Comments?