### PR TITLE
extract: Do not drop __duplicate__ metadata fields when serializing

### DIFF
--- a/beangulp/extract.py
+++ b/beangulp/extract.py
@@ -111,15 +111,11 @@ def print_extracted_entries(entries, file):
 
     # Print out the entries.
     for entry in entries:
-        # Check if this entry is a dup, and if so, comment it out.
-        if DUPLICATE_META in entry.meta:
-            meta = entry.meta.copy()
-            meta.pop(DUPLICATE_META)
-            entry = entry._replace(meta=meta)
-            entry_string = textwrap.indent(printer.format_entry(entry), '; ')
-        else:
-            entry_string = printer.format_entry(entry)
-        pr(entry_string)
+        string = printer.format_entry(entry)
+        # If this entry is a duplicate, comment it out.
+        if entry.meta.get(DUPLICATE_META, False):
+            string = textwrap.indent(string, '; ')
+        pr(string)
 
     pr('')
 


### PR DESCRIPTION
Beancount serialization learnt to ignore all metadata fields whose key
starts with a double underscore. This allow to leave the __duplicate__
metadata field alone when printing the extracted entries and thus
spares copying entries around.