### PR TITLE
Fix and extend deduplication

### DIFF
--- a/beangulp/__init__.py
+++ b/beangulp/__init__.py
@@ -84,18 +84,25 @@ def _extract(ctx, src, output, existing, reverse, failfast, quiet):
 
             # Extract entries.
             entries = extract.extract_from_file(importer, filename, existing_entries)
-            extracted.append((filename, entries))
+            account = importer.account(filename)
+
+            extracted.append((filename, entries, account, importer))
             log(' OK', fg='green')
 
         if failfast and errors:
             break
 
-    for func in ctx.hooks:
+    # Sort extracted entries.
+    extract.sort_extracted_entries(extracted)
+
+    # Invoke hooks.
+    hooks = [extract.find_duplicate_entries] if ctx.hooks is None else ctx.hooks
+    for func in hooks:
         extracted = func(extracted, existing_entries)
 
     # Reverse sort order, if requested.
     if reverse:
-        for filename, entries in extracted:
+        for filename, entries, account, importer in extracted:
             entries.reverse()
 
     # Serialize entries.

--- a/beangulp/extract.py
+++ b/beangulp/extract.py
@@ -66,6 +66,17 @@ def find_duplicate_entries(extracted, existing):
       entries marked setting the "__duplicate__" metadata field to True.
 
     """
+
+    # Ensure that the existing entries are sorted by date.
+    # find_similar_entries() uses bisection to reduce the list of
+    # existing entries to the set in a narrow date interval around the
+    # date of each entry in the set it is comparing against. This
+    # requires that the existing entries are sorted by date. Do the
+    # sorting here to avoid to have to repeat it for each entries
+    # group in the extracted list. Sorting the existing entries does
+    # not have any effect of the result of the extraction.
+    existing.sort(key=operator.attrgetter('date'))
+
     ret = []
     for filepath, entries in extracted:
         pairs = similar.find_similar_entries(entries, existing)

--- a/beangulp/extract_test.py
+++ b/beangulp/extract_test.py
@@ -58,7 +58,7 @@ class TestDuplicates(unittest.TestCase):
             1970-01-01 * "Test"
               Assets:Tests  10.00 USD'''))
         extracted = [
-            ('/path/to/test.csv', entries),
+            ('/path/to/test.csv', entries, None, None),
         ]
         marked = extract.find_duplicate_entries(extracted, entries)
         self.assertTrue(marked[0][1][0].meta[extract.DUPLICATE])
@@ -72,8 +72,8 @@ class TestPrint(unittest.TestCase):
               Assets:Tests  10.00 USD'''))
 
         extracted = [
-            ('/path/to/test.csv', entries),
-            ('/path/to/empty.pdf', []),
+            ('/path/to/test.csv', entries, None, None),
+            ('/path/to/empty.pdf', [], None, None),
         ]
 
         output = io.StringIO()
@@ -105,7 +105,7 @@ class TestPrint(unittest.TestCase):
         entries[1].meta[extract.DUPLICATE] = True
 
         extracted = [
-            ('/path/to/test.csv', entries),
+            ('/path/to/test.csv', entries, None, None),
         ]
 
         output = io.StringIO()

--- a/beangulp/similar.py
+++ b/beangulp/similar.py
@@ -16,26 +16,25 @@ from beancount.core import amount
 from beancount.core import interpolate
 
 
-def find_similar_entries(entries, source_entries, comparator=None, window_days=2):
+def find_similar_entries(entries, existing_entries, comparator=None, window_days=2):
     """Find which entries from a list are potential duplicates of a set.
 
-    Note: If there are multiple entries from 'source_entries' matching an entry
-    in 'entries', only the first match is returned. Note that this function
-    could in theory decide to merge some of the imported entries with each
-    other.
+    The existing_entries array must be sorted by date. If there are
+    multiple entries in existing_entries matching an entry in entries,
+    only the first match is returned.
 
     Args:
       entries: The list of entries to classify as duplicate or note.
-      source_entries: The list of entries against which to match. This is the
-        previous, or existing set of entries to compare against. This may be null
-        or empty.
+      existing_entries: The list of entries against which to match.
       comparator: A functor used to establish the similarity of two entries.
       window_days: The number of days (inclusive) before or after to scan the
         entries to classify against.
+
     Returns:
-      A list of pairs of entries (entry, source_entry) where entry is from
-      'entries' and is deemed to be a duplicate of source_entry, from
-      'source_entries'.
+      A list of (entry, existing_entry) tuples where entry is from
+      entries and is deemed to be a duplicate of existing_entry, from
+      existing_entries.
+
     """
     window_head = datetime.timedelta(days=window_days)
     window_tail = datetime.timedelta(days=window_days + 1)
@@ -45,14 +44,14 @@ def find_similar_entries(entries, source_entries, comparator=None, window_days=2
 
     # For each of the new entries, look at existing entries at a nearby date.
     duplicates = []
-    if source_entries is not None:
+    if existing_entries is not None:
         for entry in data.filter_txns(entries):
-            for source_entry in data.filter_txns(
-                    data.iter_entry_dates(source_entries,
+            for existing_entry in data.filter_txns(
+                    data.iter_entry_dates(existing_entries,
                                           entry.date - window_head,
                                           entry.date + window_tail)):
-                if comparator(entry, source_entry):
-                    duplicates.append((entry, source_entry))
+                if comparator(entry, existing_entry):
+                    duplicates.append((entry, existing_entry))
                     break
     return duplicates
 

--- a/examples/import.py
+++ b/examples/import.py
@@ -63,8 +63,8 @@ def process_extracted_entries(extracted_entries_list, ledger_entries):
       A possibly different version of extracted_entries_list, a list of
       (filename, entries), to be printed.
     """
-    return [(filename, clean_up_descriptions(entries))
-            for filename, entries in extracted_entries_list]
+    return [(filename, clean_up_descriptions(entries), account, importer)
+            for filename, entries, account, importer in extracted_entries_list]
 
 
 hooks = [process_extracted_entries]


### PR DESCRIPTION
Two small commits on top of #58. @blais I think I found why deduplication does not work reliably for you. See commit 45bcdf0. Commit d81fa2b extends the deduplication mechanism to work for entries within the same extract run as proposed in #9. Despite my initial schepticism, I think the algorithm I found makes a lot of sense.