### PR TITLE
mimetypes: Add text/beancount to the recognized MIME types.

### DIFF
--- a/beangulp/mimetypes.py
+++ b/beangulp/mimetypes.py
@@ -2,6 +2,7 @@ from mimetypes import *
 
 # Register some MIME types used in financial downloads.
 _extra_mime_types = [
+    ('text/beancount', '.beancount', '.beans'), # Beancount ledgers.
     ('application/vnd.intu.qbo', '.qbo'), # Quicken files.
     ('application/x-ofx', '.qfx', '.ofx'), # Open Financial Exchange files.
 ]


### PR DESCRIPTION
Associate .beancount and .beans extensions to text/beancount MIME type.