### PR TITLE
setup: Add click library to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 git+https://github.com/beancount/beancount#egg=beancount
-chardet
 beautifulsoup4
+chardet
+click >7.0
 lxml
-python-magic>=0.4.12; sys_platform != 'win32'
+python-magic >=0.4.12; sys_platform != 'win32'

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,8 @@ include_package_data = True
 packages = find:
 install_requires =
     beancount >=3.0.dev0
-    chardet
     beautifulsoup4
+    chardet
+    click >7.0
     lxml
     python-magic >=0.4.12; sys_platform != 'win32'


### PR DESCRIPTION
This was forgotten when the command line interface was ported to use
Click for command line argument parsing. The library is installed as a
dependency of beancount so things were working anyhow.