### PR TITLE
cache: Fix FileMemo.head() unicode decoding

### DIFF
--- a/beangulp/cache.py
+++ b/beangulp/cache.py
@@ -7,6 +7,7 @@ text, can be expensive.
 __copyright__ = "Copyright (C) 2016  Martin Blais"
 __license__ = "GNU GPLv2"
 
+import codecs
 import functools
 import os
 import pickle
@@ -91,16 +92,24 @@ def mimetype(filename):
 def head(num_bytes=8192, encoding=None):
     """A converter that just reads the first bytes of a file.
 
+    Note that the returned string may represent less bytes than
+    specified if the encoded bytes read from the file terminate with
+    an incomplete unicode character. This is likely to occur for
+    variable width encodings suach as utf8.
+
     Args:
       num_bytes: The number of bytes to read.
     Returns:
       A converter function.
     """
     def head_reader(filename):
-        with open(filename, 'rb') as file:
-            rawdata = file.read(num_bytes)
-            file_encoding = encoding or chardet.detect(rawdata)['encoding']
-            return rawdata.decode(file_encoding)
+        with open(filename, 'rb') as fd:
+            data = fd.read(num_bytes)
+            enc = encoding or chardet.detect(data)['encoding']
+            # A little trick to handle an encoded byte array that
+            # terminates with an incomplete unicode character.
+            decoder = codecs.iterdecode(iter([data]), enc)
+            return next(decoder)
     return head_reader
 
 

--- a/beangulp/cache_test.py
+++ b/beangulp/cache_test.py
@@ -3,6 +3,7 @@ __license__ = "GNU GPLv2"
 
 import os
 import shutil
+import sys
 import tempfile
 import time
 import unittest
@@ -55,13 +56,23 @@ class TestFileMemo(unittest.TestCase):
                                      'text/c++'})
 
     def test_cache_head_obeys_explict_utf8_encoding_avoids_chardet_exception(self):
-        emoji_header = 'asciiHeader1,🍏Header1,asciiHeader2'.encode('utf-8')
-        with mock.patch('builtins.open',
-                mock.mock_open(read_data=emoji_header)):
-            try:
-                function_return = cache._FileMemo('anyFile').head(encoding='utf-8')
-            except UnicodeDecodeError:
-                self.fail("Failed to decode emoji")
+        data = b'asciiHeader1,\xf0\x9f\x8d\x8fHeader1,asciiHeader2'
+        with mock.patch('builtins.open', mock.mock_open(read_data=data)):
+            string = cache._FileMemo('filepath').head(encoding='utf-8')
+            self.assertEqual(string, data.decode('utf8'))
+
+    def test_cache_head_encoding(self):
+        data = b'asciiHeader1,\xf0\x9f\x8d\x8fHeader1,asciiHeader2'
+        # The 15th bytes is in the middle of the unicode character.
+        num_bytes = 15
+        if sys.version_info < (3, 7):
+            # Reading the documentation, a partial read from longer
+            # mocked file data should work just fine, however, this
+            # does not seem the case in practice.
+            data = data[:num_bytes]
+        with mock.patch('builtins.open', mock.mock_open(read_data=data)):
+            string = cache._FileMemo('filepath').head(num_bytes, encoding='utf-8')
+            self.assertEqual(string, 'asciiHeader1,')
 
 
 class CacheTestCase(unittest.TestCase):


### PR DESCRIPTION
Fix file head byte data decoding when the byte string read from the
file terminates in the middle of an unicode character represented by
more than one byte. This is likely to occur for vaiable width
encodings such as utf8 with languages that uses characters beyond the
ascii set.

FileMemo is deprecated, but it should work correcly as long as it exists.

Fixes #7.