### PR TITLE
tests: Make all tests not executable as scripts

### DIFF
--- a/beangulp/file_type_test.py
+++ b/beangulp/file_type_test.py
@@ -87,7 +87,3 @@ class TestFileType(unittest.TestCase):
     @unittest.skipIf(not file_type.magic, 'python-magic is not installed')
     def test_bz2(self):
         self.check_mime_type('example.bz2', 'application/x-bzip2')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/beangulp/importer_test.py
+++ b/beangulp/importer_test.py
@@ -19,7 +19,3 @@ class TestImporterProtocol(unittest.TestCase):
         self.assertFalse(imp.file_account(memo))
         self.assertFalse(imp.file_date(memo))
         self.assertFalse(imp.file_name(memo))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/beangulp/importers/config_test.py
+++ b/beangulp/importers/config_test.py
@@ -49,7 +49,3 @@ class TestConfigMixin(unittest.TestCase):
         config['asset_other'] = 'Assets:Other'
         with self.assertRaises(ValueError):
             SimpleTestImporter(config)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/beangulp/importers/csv.py
+++ b/beangulp/importers/csv.py
@@ -1,5 +1,10 @@
-"""CSV importer.
-"""
+"""CSV importer."""
+
+# Postpone evaluation of annotations. This solves an issue with the
+# import of the standard library csv module when this module or its
+# associated test are executed as scripts. This requires Python >3.7
+# and has to wait till we will drop suppport for Python 3.6
+# from __future__ import annotations
 
 __copyright__ = "Copyright (C) 2016  Martin Blais"
 __license__ = "GNU GPLv2"

--- a/beangulp/importers/csv_test.py
+++ b/beangulp/importers/csv_test.py
@@ -529,7 +529,3 @@ class TestCSVImporter(cmptest.TestCase):
 # TODO: Add balances every month or week.
 # TODO: Test ascending and descending orders.
 # TODO: Add a test for all the supported fields, e.g. NARRATION2.
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/beangulp/importers/fileonly_test.py
+++ b/beangulp/importers/fileonly_test.py
@@ -35,7 +35,3 @@ class TestFileOnly(unittest.TestCase):
         self.assertTrue(importer.identify(file))
 
         assert importer.file_name(file).startswith('bofa.')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/beangulp/similar_test.py
+++ b/beangulp/similar_test.py
@@ -2,7 +2,6 @@ __copyright__ = "Copyright (C) 2016  Martin Blais"
 __license__ = "GNU GPLv2"
 
 import datetime
-import unittest
 
 from beancount.core.number import D
 from beancount.core import data
@@ -169,7 +168,3 @@ class TestSimilarityComparator(cmptest.TestCase):
         compare(False, 'base', 'out-bounds')
         compare(False, 'base', 'too-late')
         compare(False, 'base', 'non-accounts')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/examples/importers/tests/test_ofx.py
+++ b/examples/importers/tests/test_ofx.py
@@ -3,7 +3,6 @@ __license__ = "GNU GPLv2"
 
 import datetime
 import re
-import unittest
 
 import bs4
 
@@ -530,7 +529,3 @@ class TestOFXImporter(cmptest.TestCase):
           2014-01-03 balance Liabilities:CreditCard   200.00 USD
         """, dedent=True)
         self.assertEqualEntries(balance_entries, entries)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
This is prompt by an issue with the import of the standard library
csv module when executing beangulp/importers/csv_test.py as a script:
it fails because in this case sys.path is extended with the location
of the test script which contains a csv module that shadows the
standard library one.

Both unittest and pytest allow to easily load tests from specific
modules, which is a better solution than making each test module a
standalone script. For example, it allows to use relative import
paths.