### PR TITLE
Consider duplicates inside imported files.

### DIFF
--- a/beangulp/__init__.py
+++ b/beangulp/__init__.py
@@ -70,6 +70,7 @@ def _extract(ctx, src, output, existing, reverse, failfast, quiet):
 
     # Load the ledger, if one is specified.
     existing_entries = loader.load_file(existing)[0] if existing else []
+    accumulated_entries = existing_entries[:]
 
     extracted = []
     for filename in _walk(src, log):
@@ -83,8 +84,9 @@ def _extract(ctx, src, output, existing, reverse, failfast, quiet):
             log(' ...', nl=False)
 
             # Extract entries.
-            entries = extract.extract_from_file(importer, filename, existing_entries)
+            entries = extract.extract_from_file(importer, filename, accumulated_entries)
             extracted.append((filename, entries))
+            accumulated_entries.extend(entries)
             log(' OK', fg='green')
 
         if failfast and errors:


### PR DESCRIPTION
Specifically, if existing transactions are empty, and a.csv and b.csv contain
overlapping transactions (e.g. A contains T1, T2, and B contains T2,
T3), then before this commit, output would be {T1, T2, T2, T3}, and
after this commit output will be {T1, T2, T3} as one would expect.

This should address the first problem mentioned in beancount/beangulp#93