### PR TITLE
Add Option to Strip Existing Date During Archive

### DIFF
--- a/beangulp/__init__.py
+++ b/beangulp/__init__.py
@@ -116,8 +116,10 @@ def _extract(ctx, src, output, existing, reverse, failfast, quiet):
               help='Just print where the files would be moved.')
 @click.option('--failfast', '-x', is_flag=True,
               help='Stop processing at the first error.')
+@click.option('--strip-date', '-sd', is_flag=True,
+              help='Remove existing date from filename if it exists.')
 @click.pass_obj
-def _archive(ctx, src, destination, dry_run, overwrite, failfast):
+def _archive(ctx, src, destination, dry_run, overwrite, failfast, strip_date):
     """Archive documents.
 
     Walk the SRC list of files or directories and move each file
@@ -155,7 +157,7 @@ def _archive(ctx, src, destination, dry_run, overwrite, failfast):
             # Signal processing of this document.
             log(' ...', nl=False)
 
-            destpath = archive.filepath(importer, filename)
+            destpath = archive.filepath(importer, filename, strip_date)
 
             # Prepend destination directory path.
             destpath = os.path.join(destination, destpath)

--- a/beangulp/archive.py
+++ b/beangulp/archive.py
@@ -9,7 +9,7 @@ from beangulp import utils
 from beangulp.exceptions import Error
 
 
-def filepath(importer, filepath: str) -> str:
+def filepath(importer, filepath: str, strip_date=False) -> str:
     """Compute filing path for a document.
 
     The path mirrors the structure of the accounts associated to the
@@ -39,7 +39,10 @@ def filepath(importer, filepath: str) -> str:
         raise Error("The filename contains path separator character.")
 
     if re.match(r'\d\d\d\d-\d\d-\d\d\.', filename):
-        raise Error("The filename contains what looks like a date.")
+        if strip_date:
+            filename = re.sub(r'\d\d\d\d-\d\d-\d\d\.', '', filename)
+        else:
+            raise Error("The filename contains what looks like a date.")
 
     # Prepend account directory and date prefix.
     filename = os.path.join(account.replace(':', os.sep), f'{date:%Y-%m-%d}.{filename:}')

--- a/beangulp/archive_test.py
+++ b/beangulp/archive_test.py
@@ -47,3 +47,9 @@ class TestFilepath(unittest.TestCase):
         with self.assertRaises(exceptions.Error) as ex:
             filepath = archive.filepath(importer, path.abspath('test.pdf'))
         self.assertRegex(ex.exception.message, r'contains [\w\s]+ date')
+
+    def test_filepath_strip_date_in_name(self):
+        importer = mock.MagicMock(wraps=self.importer)
+        importer.filename.return_value = '1970-01-03.name.pdf'
+        filepath = archive.filepath(importer, path.abspath('test.pdf'), strip_date=True)
+        self.assertEqual(filepath, 'Assets/Tests/1970-01-01.name.pdf')

--- a/beangulp/tests/archive.rst
+++ b/beangulp/tests/archive.rst
@@ -120,7 +120,31 @@ Cleanup documents directory:
 
   >>> rmtree(documents)
   >>> mkdir(documents)
-  
+
+Strip existing date
+
+  >>> with open(path.join(downloads, '1970-01-03.name.csv'), 'w') as f:
+  ...     pass
+
+  >>> r = run('archive', downloads, '-o', documents, '-sd')
+  >>> r.exit_code
+  0
+  >>> print(r.output)
+  * .../downloads/1970-01-03.name.csv ... OK
+    .../documents/Assets/Tests/1970-01-01.name.csv
+  * .../downloads/aaa.txt
+  * .../downloads/zzz.txt
+
+  >>> path.exists(path.join(downloads, '1970-01-03.name.csv'))
+  False
+  >>> path.exists(path.join(documents, 'Assets/Tests/1970-01-01.name.csv'))
+  True
+
+Cleanup documents directory:
+
+  >>> rmtree(documents)
+  >>> mkdir(documents)
+
 Collision in destination filename:
 
   >>> fnames = ['aaa.txt', 'bbb.csv', 'zzz.txt', 'error.foo']


### PR DESCRIPTION
Sometime I save file with an initial save date, but the transaction date isn't for a few days later. This makes it easy to update the file instead of having to deal with the error.