### PR TITLE
Add Option to Skip Sections During Extract

### DIFF
--- a/beangulp/__init__.py
+++ b/beangulp/__init__.py
@@ -49,12 +49,14 @@ def _walk(file_or_dirs, log):
               help='Existing Beancount ledger for de-duplication.')
 @click.option('--reverse', '-r', is_flag=True,
               help='Sort entries in reverse order.')
+@click.option('--no-sections', '-ns', is_flag=True,
+              help='Separate files into sections')
 @click.option('--failfast', '-x', is_flag=True,
               help='Stop processing at the first error.')
 @click.option('--quiet', '-q', count=True,
               help="Suppress all output.")
 @click.pass_obj
-def _extract(ctx, src, output, existing, reverse, failfast, quiet):
+def _extract(ctx, src, output, existing, reverse, no_sections, failfast, quiet):
     """Extract transactions from documents.
 
     Walk the SRC list of files or directories and extract the ledger
@@ -99,7 +101,7 @@ def _extract(ctx, src, output, existing, reverse, failfast, quiet):
             entries.reverse()
 
     # Serialize entries.
-    extract.print_extracted_entries(extracted, output)
+    extract.print_extracted_entries(extracted, output, no_sections)
 
     if errors:
         sys.exit(1)

--- a/beangulp/extract.py
+++ b/beangulp/extract.py
@@ -130,7 +130,7 @@ def mark_duplicate_entries(
     return marked
 
 
-def print_extracted_entries(extracted, output):
+def print_extracted_entries(extracted, output, no_sections=False):
     """Print extracted entries.
 
     Entries marked as duplicates are printed as comments.
@@ -145,16 +145,34 @@ def print_extracted_entries(extracted, output):
     if extracted:
         output.write(HEADER + '\n')
 
+    if not no_sections:
+        print_with_sections(extracted, output)
+    else:
+        print_without_sections(extracted, output)
+
+
+def print_without_sections(extracted, output):
+    merged = []
+    for _, entries in extracted:
+        for entry in entries:
+            merged.append(entry)
+    print_entries(sorted(merged, key=lambda x: x.date), output)
+
+
+def print_with_sections(extracted, output):
     for filepath, entries in extracted:
         output.write(SECTION.format(filepath) + '\n\n')
 
-        for entry in entries:
-            duplicate = entry.meta.pop(DUPLICATE, False)
-            string = printer.format_entry(entry)
-            # If the entry is a duplicate, comment it out.
-            if duplicate:
-                string = textwrap.indent(string, '; ')
-            output.write(string)
-            output.write('\n')
+        print_entries(entries, output)
+        output.write('\n')
 
+
+def print_entries(entries, output):
+    for entry in entries:
+        duplicate = entry.meta.pop(DUPLICATE, False)
+        string = printer.format_entry(entry)
+        # If the entry is a duplicate, comment it out.
+        if duplicate:
+            string = textwrap.indent(string, '; ')
+        output.write(string)
         output.write('\n')

--- a/beangulp/extract_test.py
+++ b/beangulp/extract_test.py
@@ -93,6 +93,34 @@ class TestPrint(unittest.TestCase):
 
             '''))
 
+    def test_print_extracted_entries_no_sections(self):
+        entries1, error, options = parser.parse_string(textwrap.dedent('''
+            1975-01-01 * "Test1"
+              Assets:Tests  10.00 USD'''))
+
+        entries2, error, options = parser.parse_string(textwrap.dedent('''
+            1970-01-01 * "Test2"
+              Assets:Tests  10.00 USD'''))
+
+        extracted = [
+            ('/path/to/test.csv', entries1),
+            ('/path/to/test.csv', entries2),
+        ]
+
+        output = io.StringIO()
+        extract.print_extracted_entries(extracted, output, True)
+
+        self.assertEqual(output.getvalue(), textwrap.dedent('''\
+            ;; -*- mode: beancount -*-
+
+            1970-01-01 * "Test2"
+              Assets:Tests  10.00 USD
+
+            1975-01-01 * "Test1"
+              Assets:Tests  10.00 USD
+
+            '''))
+
     def test_print_extracted_entries_duplictes(self):
         entries, error, options = parser.parse_string(textwrap.dedent('''
             1970-01-01 * "Test"

--- a/beangulp/tests/extract.rst
+++ b/beangulp/tests/extract.rst
@@ -78,6 +78,16 @@ Check the output file:
   **** .../downloads/bbb.csv
   <BLANKLINE>
 
+Disable Sections
+
+  >>> r = run('extract', downloads, '-o', output, '-ns')
+  >>> r.exit_code
+  0
+  >>> with open(output, 'r') as f:
+  ...     extracted = f.read()
+  >>> print(extracted)
+  ;; -*- mode: beancount -*-
+
 Test importer raising an error:
 
   >>> with open(path.join(downloads, 'error.foo'), 'w') as f:


### PR DESCRIPTION
I prefer to have a single output file with all transactions (entities) sorted by date instead of the default behavior to add a section for each imported file. This option will accomplish that.