### PR TITLE
Fix MIME type check for example OFX importer.

### DIFF
--- a/beangulp/__init__.py
+++ b/beangulp/__init__.py
@@ -188,8 +188,8 @@ def _archive(ctx, src, destination, dry_run, overwrite, failfast):
         sys.exit(1)
 
     if not dry_run:
-        for src, dst in renames:
-            archive.move(src, dst)
+        for filename, destpath in renames:
+            archive.move(filename, destpath)
 
 
 @click.command('identify')

--- a/examples/importers/ofx.py
+++ b/examples/importers/ofx.py
@@ -66,7 +66,7 @@ class Importer(beangulp.Importer):
 
     def identify(self, filepath):
         # Match for a compatible MIME type.
-        if mimetypes.guess_type(filepath) not in {'application/x-ofx',
+        if mimetypes.guess_type(filepath, strict=False)[0] not in {'application/x-ofx',
                                                   'application/vnd.intu.qbo',
                                                   'application/vnd.intu.qfx'}:
             return False


### PR DESCRIPTION
Ensure that we will accept the non-strict type we added, and don't try to match a tuple against a string. Without this, type check will always fail, and no files will pass identification.