### PR TITLE
Support CSV files where the amount isn't in a single column and the value embeds currency symbol

### DIFF
--- a/beangulp/importers/csvbase.py
+++ b/beangulp/importers/csvbase.py
@@ -262,8 +262,13 @@ class Importer(beangulp.Importer, CSVReader):
         """Implement beangulp.Importer::extract()
 
         This methods costructs a transaction for each data row using
-        the date, narration, and amount required fields and the flag,
+        the date, narration required fields and the flag,
         payee, account, currency, tag, link, balance optional fields.
+
+        The amount() method returns the amount for a row---the default
+        implementation requires an amount field. The method can be
+        redefined in subclasses---for use cases where the amount is
+        derived from multiple columns, e.g. deposit and withdrawal.
 
         Transaction metadata is constructed with the metadata() method
         and the finalize() method is called on each transaction. These
@@ -299,7 +304,7 @@ class Importer(beangulp.Importer, CSVReader):
             payee = getattr(row, 'payee', None)
             account = getattr(row, 'account', default_account)
             currency = getattr(row, 'currency', self.currency)
-            units = data.Amount(row.amount, currency)
+            units = data.Amount(self.amount(row), currency)
 
             # Create a transaction.
             txn = data.Transaction(self.metadata(filepath, lineno, row),
@@ -333,6 +338,9 @@ class Importer(beangulp.Importer, CSVReader):
             entries.append(max(balances, key=lambda x: x.date))
 
         return entries
+
+    def amount(self, row) -> decimal.Decimal:
+        return row.amount
 
     def metadata(self, filepath, lineno, row):
         """Build transaction metadata dictionary.

--- a/beangulp/importers/csvbase.py
+++ b/beangulp/importers/csvbase.py
@@ -9,6 +9,7 @@ from itertools import islice
 from beancount.core import data
 
 import beangulp
+from beangulp import utils
 
 EMPTY = frozenset()
 
@@ -146,7 +147,7 @@ class Amount(Column):
     def parse(self, value):
         for pattern, replacement in self.subs.items():
             value = re.sub(pattern, replacement, value)
-        return decimal.Decimal(value)
+        return utils.parse_amount(value)
 
 
 # The CSV Importer class needs to inherit from beangulp.Importer which


### PR DESCRIPTION
Support use cases where the CSV file doesn't have amount in a single column---instead the amount is derived from multiple columns. In my case (see unit test case [test_extract_amount](https://github.com/rajive/beangulp/blob/0892d2c73364a5e21a128d04d83deae27b72203c/beangulp/importers/csvbase_test.py#L424)), the bank's CSV had a "Withdrawal" column and a "Deposit" column. In each row, only one on those columns has a positive numeric value. 

Furthermore, the numeric value embeds currency ('$') symbol with comma separated digits that were not being parsed correctly.