### PR TITLE
Provide for passing through arguments to cli via Ingest

### DIFF
--- a/beangulp/__init__.py
+++ b/beangulp/__init__.py
@@ -281,5 +281,5 @@ class Ingest:
 
         self.cli = cli
 
-    def __call__(self):
-        return self.cli()
+    def __call__(self, *args, **kwargs):
+        return self.cli(*args, **kwargs)


### PR DESCRIPTION
This PR would allow users to pass through arguments to the click cli via the call to Ingest.

My particular case for requiring this is to be able to pass through the `standalone_mode` argument as False when testing. (This prevents the system from exiting after the execution instigated by the cli has finished. I might well be going about testing in the wrong way - I just simulate command line instructions).

I'd note that (at least some of) the arguments are passed through to at least `click.core.BaseCommand.main`. I haven't looked under-the-bonnet of the click decorators (on the `cli` function defined in `Ingest`) and don't know where else they might end up - I'm comfortable offering the PR given that I can't see how it could change any existing behaviour.

Anyway, one for you to consider.

Thank you as ever for all the work that continues to go into beancount and these supporting packages! It's very much appreciated.