### PR TITLE
build, ci: Drop support for Python 3.7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
@@ -22,8 +21,6 @@ jobs:
           - '@git+https://github.com/beancount/beancount.git'
         exclude:
           # Beancount dev version requires Python 3.9+
-          - beancount: '@git+https://github.com/beancount/beancount.git'
-            python: '3.7'
           - beancount: '@git+https://github.com/beancount/beancount.git'
             python: '3.8'
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ keywords = ['accounting', 'ledger', 'beancount', 'importer', 'import', 'converte
 classifiers = [
     'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
Testing with Python 3.7 is becoming increasingly difficult because actions/install-python dropped support for it. Python 3.7 is EOL since 2023-06-27: there is very little value in keeping supporting it.