### PR TITLE
Allow get_file to take _FileMemo input

### DIFF
--- a/beangulp/cache.py
+++ b/beangulp/cache.py
@@ -150,6 +150,8 @@ def get_file(filename):
       A FileMemo instance.
 
     """
+    if isinstance(filename, _FileMemo):
+        filename = filename.name
     assert path.isabs(filename), (
         "Path should be absolute in order to guarantee a single call.")
     return _CACHE[filename]

--- a/beangulp/cache_test.py
+++ b/beangulp/cache_test.py
@@ -30,6 +30,12 @@ class TestFileMemo(unittest.TestCase):
             self.assertEqual('abc', wrap.convert(converter))
             self.assertEqual(1, converter.call_count)
 
+            # Check that get_file can be called on a _FileMemo.
+            self.assertNotEqual(wrap, cache.get_file(tmpfile.name))
+            self.assertNotEqual(wrap, cache.get_file(wrap))
+            self.assertEqual(wrap.name, cache.get_file(tmpfile.name).name)
+            self.assertEqual(wrap.name, cache.get_file(wrap).name)
+
     def test_cache_head_and_contents(self):
         with tempfile.NamedTemporaryFile(suffix='.py') as tmpfile:
             shutil.copy(__file__, tmpfile.name)


### PR DESCRIPTION
Currently `beangulp.cache.get_file` will error if it is given a `_FileMemo` as input:

```
TypeError: expected str, bytes or os.PathLike object, not _FileMemo
```

This can be inconvenient in some situations; for example, the implementation of `CSVImporter.identify` is:

```python
def identify(self, filepath):
     return self.ident.identify(cache.get_file(filepath))
```

So this will error if `filepath` happens to already be a `_FileMemo`.

This makes the implementation of `get_file` slightly more flexible, to allow repeated applications of itself without causing an error.