### PR TITLE
Don't merge deduped entries into existing_entries.

### DIFF
--- a/beangulp/__init__.py
+++ b/beangulp/__init__.py
@@ -96,9 +96,12 @@ def _extract(ctx, src, output, existing, reverse, failfast, quiet):
     extract.sort_extracted_entries(extracted)
 
     # Deduplicate.
+    deduplicated_new_entries = []
     for filename, entries, account, importer in extracted:
-        importer.deduplicate(entries, existing_entries)
-        existing_entries.extend(entries)
+        # We want to deduplicate not just against existing_entries
+        # but also new entries from other importers in this run
+        importer.deduplicate(entries, existing_entries + deduplicated_new_entries)
+        deduplicated_new_entries.extend(entries)
 
     # Invoke hooks.
     for func in ctx.hooks:


### PR DESCRIPTION
Merging pollutes the existing_entries for hooks that get run later. Instead we track them separately but consider the union(existing_entries, new_entries) when running the deduplication logic, since we also want to remove duplicates from other importers in this same.