### PR TITLE
fix(csvbase): do not persist auto-detected self.order

### DIFF
--- a/beangulp/importers/config_test.py
+++ b/beangulp/importers/config_test.py
@@ -21,8 +21,7 @@ class SimpleTestImporter(config.ConfigImporterMixin,
 class TestConfigMixin(unittest.TestCase):
 
     def setUp(self):
-        self.default_config = {key: 'Assets:Something'
-                               for key in SimpleTestImporter.REQUIRED_CONFIG}
+        self.default_config = dict.fromkeys(SimpleTestImporter.REQUIRED_CONFIG, 'Assets:Something')
 
     def test_constructors(self):
         # Test invalid input type.

--- a/beangulp/importers/csvbase.py
+++ b/beangulp/importers/csvbase.py
@@ -395,15 +395,17 @@ class Importer(beangulp.Importer, CSVReader):
             return []
 
         if self.order is None:
-            self.order = Order.ASCENDING if entries[0].date <= entries[-1].date else Order.DESCENDING
+            order = Order.ASCENDING if entries[0].date <= entries[-1].date else Order.DESCENDING
+        else:
+            order = self.order
 
         # Reverse the list if the file is in descending order.
-        if self.order is Order.DESCENDING:
+        if order is Order.DESCENDING:
             entries.reverse()
 
         # Append balances.
         for currency, balances in balances.items():
-            entries.append(balances[-1 if self.order is Order.ASCENDING else 0])
+            entries.append(balances[-1 if order is Order.ASCENDING else 0])
 
         return entries
 


### PR DESCRIPTION
Today when I batch import two years of statements for a rarely-used account, I find this auto detection of row order might produce incorrect results.

For example, there is only one transaction in January:

```
2023-01-31,...
```

... and four transactions in February:

```
2023-02-28,...
2023-02-20,...
2023-02-11,...
2023-02-05,...
```

When processing the January file, the code auto-detects the order as `ASCENDING` as there is only one transaction, and for _Feburary and any subsequent files_, the code no longer tries to detect the order because `self.order` is already set. But this bank actually uses `DESCENDING` order for their files.

This error might be masked if the entries are eventually sorted. But I disabled sorting for some other reason so I hit this edge case.
