### PR TITLE
add __all__ to explicitly declare exports of beangulp

### DIFF
--- a/beangulp/__init__.py
+++ b/beangulp/__init__.py
@@ -22,12 +22,26 @@ from typing import Optional
 from typing import List
 
 from beangulp import archive
-from beangulp import cache  # noqa: F401
+from beangulp import cache
 from beangulp import exceptions
 from beangulp import extract
 from beangulp import identify
 from beangulp import utils
 from beangulp.importer import Importer, ImporterProtocol, Adapter
+
+
+__all__ = [
+    "Adapter",
+    "Importer",
+    "ImporterProtocol",
+    "Ingest",
+    "archive",
+    "cache",
+    "exceptions",
+    "extract",
+    "identify",
+    "utils",
+]
 
 
 def _walk(file_or_dirs, log):


### PR DESCRIPTION
Without this, mypy will complain when importing Importer from beangulp.

(previously part of #141)