### PR TITLE
pyproject: Adopt License-Expression (PEP 639)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [build-system]
-requires = ['setuptools >= 60.0']
+requires = ['setuptools >= 77.0.3']
 build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'beangulp'
 version = '0.3.0.dev0'
-license = { file = 'LICENSE' }
+license = 'GPL-2.0-only'
+license-files = ['LICENSE']
 description = 'Importers Framework for Beancount'
 readme = 'README.rst'
 authors = [
@@ -17,7 +18,6 @@ maintainers = [
 ]
 keywords = ['accounting', 'ledger', 'beancount', 'importer', 'import', 'converter', 'conversion']
 classifiers = [
-    'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
     'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
This further clarifies the license and shuts up a setuptools warning.