### PR TITLE
examples: Use cachier as cache

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -104,10 +104,14 @@ fava`) because this still has beancount v2.3.6 pinned (if you need fava, install
 in a different venv).
 
 Also, if you want to run the example folder fully, including pdf2text extraction, 
-install the following dependencies for pdftotext:
+install the following dependencies:
 
 ```bash
+# Contains pdf2text
 apt-get install poppler-utils
+
+# Caching lib used in the example
+pip install cachier
 ```
 
 Now run beancount with the beangulp importer:

--- a/examples/importers/acme.py
+++ b/examples/importers/acme.py
@@ -13,15 +13,15 @@ __license__ = "GNU GPLv2"
 import re
 import subprocess
 
+from cachier import cachier
 from dateutil.parser import parse as parse_datetime
 
 import beangulp
 from beangulp import mimetypes
-from beangulp.cache import cache
 from beangulp.testing import main
 
 
-@cache
+@cachier()
 def pdf_to_text(filename):
     """Convert a PDF document to a text equivalent."""
     r = subprocess.run(["pdftotext", filename, "-"], stdout=subprocess.PIPE, check=True)


### PR DESCRIPTION
Hi!

I am currently working on migrating my accounting to Beancount and am encountering a few things that I think could be improved here and there.

One such thing is the caching provided by beangulp. My usecase is to convert PDFs, but also run them through an LLM to stamp out some interesting information, the lather can take quite a bit of time.

Initially, I started out with beangulp.cache, but at some point had to make a round-trip to the source code to find out something that was clear to me. Then I found out that beangulp.cache is actually deprecated and beangulp.simple_cache succeeded it. But simple_cache was not as ergonomic to use as the first and also not released yet, so I decided on using [cachier](https://github.com/python-cachier/cachier) instead.

That left me wondering whether caching should be provided by beangulp at all. Not including a cache implementation leaves room to focus on the core domain of interfacing with Beancount.

This MR proposes to use cachier in the included example. A followup step would be deprecating all caching interfaces.

Let me know what you think of this :)