### PR TITLE
Set exit status when identify matches nothing

### DIFF
--- a/beangulp/__init__.py
+++ b/beangulp/__init__.py
@@ -254,12 +254,16 @@ def _identify(ctx: "Ingest", src: str, failfast: bool, verbose: bool):
     log = utils.logger(verbose)
     errors = exceptions.ExceptionsTrap(log)
 
+    any_importer_found = False
+
     for filename in _walk(src, log):
         with errors:
             importer = identify.identify(ctx.importers, filename)
             if not importer:
                 log("")  # Newline.
                 continue
+
+            any_importer_found = True
 
             # Signal processing of this document.
             log(" ...", nl=False)
@@ -276,6 +280,9 @@ def _identify(ctx: "Ingest", src: str, failfast: bool, verbose: bool):
 
     if errors:
         sys.exit(1)
+
+    if not any_importer_found:
+        sys.exit(100)
 
 
 def _importer(importer):

--- a/beangulp/tests/identify.rst
+++ b/beangulp/tests/identify.rst
@@ -55,7 +55,7 @@ Test with an empty downloads directory:
 
   >>> r = run('identify', downloads)
   >>> r.exit_code
-  0
+  100
   >>> print(r.output)
 
 Add some documents:


### PR DESCRIPTION
I'm trying to set up a workflow with multiple importers, one of which is a fall-back that matches kind of PDF document.

There currently is not really a way to achieve this, since beangulp does not permit multiple importers to be able to import a given file.

To work around this, I can create multiple distinct importer scripts. But these should then be able to tell whether they are able to process a given file. I think the most common way for this is to set an exit status, which is what this patch proposes.

The status being set is 100, which is distinct from any other error. The exit status is only set of no importer is available for any of the specified files,