### PR TITLE
fix: update uv invocation so that 'make test' in the top-level directory runs all the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 # Test in an isolated Python environment.
 # uv python pin <version> to set the version.
 test:
-	(env -u PYTHONPATH  uv run --isolated --python 3.13  python -m pytest)
+	(env -u PYTHONPATH  uv run --isolated --extra petl --group test --python 3.13  python -m pytest)
 
 test-all:
 	for V in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 ; do \
-		(env -u PYTHONPATH  uv run --isolated --python $$V  python -m pytest) ; \
+		(env -u PYTHONPATH  uv run --isolated --extra petl --group test --python $$V  python -m pytest) ; \
 	done


### PR DESCRIPTION
`make test` or `make` was failing as follows:

```
(env -u PYTHONPATH  uv run --isolated --python 3.13  python -m pytest)
      Built beangulp @ file:///Users/rajive/code/beangulp
Installed 14 packages in 9ms
/Users/rajive/.cache/uv/builds-v0/.tmpmSYVuT/bin/python: No module named pytest
make: *** [test] Error 1
```

The fix resolve this issue by resolving the missing dependencies `--extra petl ` and `--group test`, that are defined in the `pyproject.toml` file.