### PR TITLE
feat(csv): add windows csv mine type

### DIFF
--- a/beangulp/importers/csv.py
+++ b/beangulp/importers/csv.py
@@ -168,7 +168,8 @@ def prepare_for_identifier(
     if isinstance(regexps, str):
         regexps = [regexps]
     matchers = matchers or []
-    matchers.append(("mime", "text/csv"))
+    matchers.append(('mime', '(text/csv)|(application/vnd\\.ms-excel)'))
+    matchers.append(('filename', 'csv$'))
     if regexps:
         for regexp in regexps:
             matchers.append(("content", regexp))


### PR DESCRIPTION
When using the Windwos system to read the csv archives default mime type is application/vnd.ms-excel, I refer to https://github.com/beancount/beangulp/pull/105, but there has been no merge. Direct merge does not take into account other compatibility issues, so I added a filaname to make a judgment