### PR TITLE
Add text/org MIME type

### DIFF
--- a/beangulp/file_type_test.py
+++ b/beangulp/file_type_test.py
@@ -68,7 +68,7 @@ class TestFileType(unittest.TestCase):
 
     def test_org(self):
         self.check_mime_type(
-            "example.org", ["text/plain", "application/vnd.lotus-organizer"]
+            "example.org", ["text/org", "text/plain", "application/vnd.lotus-organizer"]
         )
 
     def test_xml(self):


### PR DESCRIPTION
This was registered with IANA on 2025-09-25
(https://www.iana.org/assignments/media-types/text/org), and the test file is detected as `text/org` on current Debian testing.