### PR TITLE
fix honouring of extract --reverse

### DIFF
--- a/beangulp/__init__.py
+++ b/beangulp/__init__.py
@@ -109,7 +109,12 @@ def _extract(
             log(" ...", nl=False)
 
             # Extract entries.
-            entries = extract.extract_from_file(importer, filename, existing_entries)
+            entries = extract.extract_from_file(
+                importer,
+                filename,
+                existing_entries,
+                reverse=reverse,
+            )
             account = importer.account(filename)
 
             extracted.append((filename, entries, account, importer))

--- a/beangulp/extract.py
+++ b/beangulp/extract.py
@@ -35,7 +35,10 @@ ExtractedEntry = Tuple[str, data.Entries, data.Account, "Importer"]
 
 
 def extract_from_file(
-    importer: "Importer", filename: str, existing_entries: "data.Directives"
+    importer: "Importer",
+    filename: str,
+    existing_entries: "data.Directives",
+    reverse: bool = False,
 ) -> data.Entries:
     """Import entries from a document.
 
@@ -43,6 +46,7 @@ def extract_from_file(
       importer: The importer instance to handle the document.
       filename: Filesystem path to the document.
       existing_entries: Existing entries.
+      reverse: Sort extracted entries in descending order.
 
     Returns:
       The list of imported entries.
@@ -52,7 +56,7 @@ def extract_from_file(
         return []
 
     # Sort the newly imported entries.
-    importer.sort(entries)
+    importer.sort(entries, reverse=reverse)
 
     # Ensure that the entries are typed correctly.
     for entry in entries:


### PR DESCRIPTION

I was writing my own importer and could not get `extract --reverse` to work, until I confirmed I was getting `reverse` as False all the time.

You can reproduce this with this test:

```diff
diff --git a/beangulp/extract_test.py b/beangulp/extract_test.py
index ceaa443..25f6cdf 100644
--- a/beangulp/extract_test.py
+++ b/beangulp/extract_test.py
@@ -1,4 +1,5 @@
 import io
+import tempfile
 import textwrap
 import unittest
 
@@ -6,7 +7,10 @@ from datetime import timedelta
 from os import path
 from unittest import mock
 
+import click.testing
+
 from beancount.parser import parser
+import beangulp
 from beangulp import extract
 from beangulp import similar
 from beangulp import tests
@@ -53,6 +57,48 @@ class TestExtract(unittest.TestCase):
         with self.assertRaises(AssertionError):
             extract.extract_from_file(importer, path.abspath("test.csv"), [])
 
+    def test_extract_reverse_flag_passed_from_cli(self):
+        entries, errors, options = parser.parse_string(
+            textwrap.dedent("""
+            1970-01-03 * "Test"
+              Assets:Tests  1.00 USD
+
+            1970-01-01 * "Test"
+              Assets:Tests  1.00 USD
+            """)
+        )
+
+        class ReverseImporter(tests.utils.Importer):
+            def __init__(self):
+                super().__init__("test.Reverse", "Assets:Tests", None)
+                self.last_reverse = None
+
+            def identify(self, filepath):
+                return True
+
+            def extract(self, filepath, existing):
+                return list(entries)
+
+            def sort(self, entries, reverse=False):
+                self.last_reverse = reverse
+                return super().sort(entries, reverse=reverse)
+
+        importer = ReverseImporter()
+        ingest = beangulp.Ingest([importer])
+        runner = click.testing.CliRunner()
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            filepath = path.join(tempdir, "test.txt")
+            with open(filepath, "w") as handle:
+                handle.write("fixture")
+
+            result = runner.invoke(
+                ingest.cli, ["extract", "--reverse", filepath], catch_exceptions=False
+            )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue(importer.last_reverse)
+
 
 class TestDuplicates(unittest.TestCase):
     def test_mark_duplicate_entries(self):
```