### PR TITLE
chore: correct typo in sort_extracted_entries docstring

### DIFF
--- a/beangulp/extract.py
+++ b/beangulp/extract.py
@@ -64,7 +64,7 @@ def extract_from_file(
 def sort_extracted_entries(extracted: List[ExtractedEntry]) -> None:
     """Sort the extraxted entries.
 
-    Sort extracged entries, grouped by source document, in the order
+    Sort extracted entries, grouped by source document, in the order
     in which they will be used in deduplication and in which they will
     be serialized to file.
 


### PR DESCRIPTION
Fix typo in docstring for sort_extracted_entries function.